### PR TITLE
[1/2] Extend `StatusItem` and `MenuItem` API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ categories = ["os::macos-apis"]
 [dependencies]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-block2 = "0.2.0"
-icrate = { version = "0.0.3", features = ["apple", "Foundation_all", "AppKit_all"] }
-objc2 = "0.4.0"
+block2 = "0.3"
+icrate = { version = "0.0.4", features = ["apple", "Foundation_all", "AppKit_all"] }
+objc2 = "0.4"
 
 [dev-dependencies]
-sysinfo = "0.29.5"
+sysinfo = "0.30"
 tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "system_status_bar_macos"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 description = "Library for interacting with the system's status bar for macOS, or more simply, the one for using [NSStatusBar systemStatusBar]."
 license = "MIT OR Apache-2.0"
@@ -23,4 +23,3 @@ tokio = { version = "1", features = ["full"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"
-

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -2,18 +2,51 @@ use std::sync::mpsc::channel;
 use system_status_bar_macos::*;
 
 fn main() {
-    let _status_item = StatusItem::new("TITLE", Menu::new(vec![
+    let mut menu_with_image = MenuItem::new(
+        "MENU WITH IMAGE",
+        Some(Box::new(|| {
+            println!("yummy!");
+        })),
+        None,
+    );
+    if let Some(coffee_image) = Image::with_system_symbol_name("mug.fill", Some("Coffee!")) {
+        menu_with_image.set_image(coffee_image);
+    }
+
+    let mut menu_with_control_state = MenuItem::new(
+        "MENU WITH CONTROL STATE",
+        Some(Box::new(|| {
+            println!("toggle control state?");
+        })),
+        None,
+    );
+    menu_with_control_state.set_control_state(ControlState::On);
+
+    let _status_item = StatusItem::new(
+        "TITLE",
+        Menu::new(vec![
             MenuItem::new("UNCLICKABLE MENU", None, None),
-            MenuItem::new("CLICKABLE MENU", Some(Box::new(|| {
-                println!("clicked!");
-            })), None),
-            MenuItem::new("PARENT MENU", None, Some(Menu::new(vec![
-                MenuItem::new("SUBMENU", None, None),
-                MenuItem::new("SUBMENU", None, None),
-            ]))),
-    ]));
+            MenuItem::new(
+                "CLICKABLE MENU",
+                Some(Box::new(|| {
+                    println!("clicked!");
+                })),
+                None,
+            ),
+            menu_with_image,
+            menu_with_control_state,
+            MenuItem::separator(),
+            MenuItem::new(
+                "PARENT MENU",
+                None,
+                Some(Menu::new(vec![
+                    MenuItem::new("SUBMENU", None, None),
+                    MenuItem::new("SUBMENU", None, None),
+                ])),
+            ),
+        ]),
+    );
 
     let (_sender, receiver) = channel::<()>();
-    sync_infinite_event_loop(receiver, |_| { });
+    sync_infinite_event_loop(receiver, |_| {});
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,19 +296,12 @@ use objc2::{
 };
 
 use icrate::{
-    Foundation::{
-        NSString,
-    },
     AppKit::{
-        NSEvent,
-        NSStatusBar,
-        NSStatusItem,
-        NSMenu,
-        NSMenuItem,
-        NSApplication,
-        NSEventMaskAny,
+        NSApplication, NSControlStateValueMixed, NSControlStateValueOff, NSControlStateValueOn,
+        NSEvent, NSEventMaskAny, NSImage, NSMenu, NSMenuItem, NSStatusBar, NSStatusItem,
         NSVariableStatusItemLength,
     },
+    Foundation::NSString,
 };
 
 use block2::{
@@ -470,6 +463,19 @@ impl STBMenuItemCallback {
     }
 }
 
+/// See `NSControl.StateValue`
+#[derive(Debug)]
+pub enum ControlState {
+    /// A constant value that indicates a control is on or selected.
+    On,
+
+    /// A constant value that indicates a control is off or unselected.
+    Off,
+
+    /// A constant value that indicates a control is in a mixed state, neither on nor off.
+    Mixed,
+}
+
 #[derive(Debug)]
 pub struct MenuItem {
     inner: Id<NSMenuItem>,
@@ -477,6 +483,7 @@ pub struct MenuItem {
     title: String,
     callback: Option<MenuItemCallback>,
     submenu: Option<Menu>,
+    control_state: ControlState,
 }
 
 impl MenuItem {
@@ -503,7 +510,13 @@ impl MenuItem {
             });
 
             let title = title.to_string();
-            Self { inner, title, callback, submenu }
+            Self {
+                inner,
+                title,
+                callback,
+                submenu,
+                control_state: ControlState::Off,
+            }
         }
     }
 
@@ -525,6 +538,7 @@ impl MenuItem {
                 title: "".to_string(),
                 callback: None,
                 submenu: None,
+                control_state: ControlState::Off,
             }
         }
     }
@@ -535,6 +549,20 @@ impl MenuItem {
     ) {
         unsafe {
             self.inner.setImage(Some(&*image.inner));
+        }
+    }
+
+    pub fn control_state(&self) -> &ControlState {
+        &self.control_state
+    }
+
+    pub fn set_control_state(&mut self, control_state: ControlState) {
+        unsafe {
+            match control_state {
+                ControlState::On => self.inner.setState(NSControlStateValueOn),
+                ControlState::Off => self.inner.setState(NSControlStateValueOff),
+                ControlState::Mixed => self.inner.setState(NSControlStateValueMixed),
+            };
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,15 @@ impl StatusItem {
             self.title = title.to_string();
         }
     }
+
+    pub fn set_image(
+        &mut self,
+        image: Image,
+    ) {
+        unsafe {
+            self.inner.button().map(|b| b.setImage(Some(&*image.inner)));
+        }
+    }
 }
 
 impl Drop for StatusItem {
@@ -517,6 +526,41 @@ impl MenuItem {
                 callback: None,
                 submenu: None,
             }
+        }
+    }
+
+    pub fn set_image(
+        &mut self,
+        image: Image,
+    ) {
+        unsafe {
+            self.inner.setImage(Some(&*image.inner));
+        }
+    }
+}
+
+pub struct Image {
+    inner: Id<NSImage>
+}
+
+impl Image {
+    /// Creates an image with the system symbol name and accessibility description you specify.
+    ///
+    /// See `SF Symbols` app in macOS App Store
+    pub fn with_system_symbol_name(
+        image_named: impl AsRef<str>,
+        accessibility_description: Option<impl AsRef<str>>,
+    ) -> Option<Self> {
+        unsafe {
+            let accessibility_description = match accessibility_description {
+                Some(description) => NSString::from_str(description.as_ref()),
+                None => NSString::new(),
+            };
+
+            let inner = NSImage::imageWithSystemSymbolName_accessibilityDescription(
+                &NSString::from_str(image_named.as_ref()),
+                Some(&*accessibility_description))?;
+            Some(Self { inner} )
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,20 @@ impl MenuItem {
     pub fn title(&self) -> &str {
         &self.title
     }
+
+    pub fn separator() -> Self {
+        unsafe {
+            let inner = NSMenuItem::separatorItem();
+
+            Self {
+                inner,
+
+                title: "".to_string(),
+                callback: None,
+                submenu: None,
+            }
+        }
+    }
 }
 
 impl Drop for MenuItem {


### PR DESCRIPTION
- Bump dependencies
- Add support for:
     - `MenuItem` separators
     - `MenuItem` state (off, on and mixed)
     - Using SF Symbols as images on `StatusItem` and `MenuItem`

Please merge this PR first 😇 
